### PR TITLE
Fix test failures caused by npm/yarn discrepancy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "minimist": "^1.2.0",
     "nlf": "^1.4.2",
     "spdx-correct": "^1.0.2"
+  },
+  "engines": {
+    "node": ">=6"
   }
 }

--- a/test/default.spec.js
+++ b/test/default.spec.js
@@ -1,16 +1,16 @@
 'use strict';
 describe('default options', () => {
 
-	const fs = require('fs');
-	const helper = require('./helper');
+	const { customMatchers, getReport, normalizeReport } = require('./helper');
 	const module = require('../');
+	const fs = require('fs');
 	const tempfile = require('tempfile');
 
 	let report, expectedReport;
 
 	beforeAll(done => {
-		jasmine.addMatchers(helper.customMatchers);
-		expectedReport = helper.getReport('default-report.txt');
+		jasmine.addMatchers(customMatchers);
+		expectedReport = getReport('default-report.txt');
 		module.generateReport()
 			.then(r => { report = r; })
 			.then(done)
@@ -26,7 +26,7 @@ describe('default options', () => {
 	});
 
 	it('toString() should return the report', () => {
-		expect(report.toString()).toBe(expectedReport);
+		expect(normalizeReport(report.toString())).toBe(expectedReport);
 	});
 
 	describe('write()', () => {
@@ -38,7 +38,7 @@ describe('default options', () => {
 
 		it('should save the report', () => {
 			report.write(outFile);
-			expect(fs.readFileSync(outFile, 'utf8')).toBe(expectedReport);
+			expect(normalizeReport(fs.readFileSync(outFile, 'utf8'))).toBe(expectedReport);
 		});
 
 	});

--- a/test/fixtures/reports/all-deps-report.txt
+++ b/test/fixtures/reports/all-deps-report.txt
@@ -2,6 +2,7 @@ Dependency Licenses
 -------------------
 
 * bower-license
+  URL: https://github.com/AceMetrix/bower-license#readme
   Version: 0.4.4
   License: Apache-2.0
   Description: Generates a list of bower dependencies for a project

--- a/test/fixtures/reports/default-report.txt
+++ b/test/fixtures/reports/default-report.txt
@@ -2,6 +2,7 @@ Dependency Licenses
 -------------------
 
 * bower-license
+  URL: https://github.com/AceMetrix/bower-license#readme
   Version: 0.4.4
   License: Apache-2.0
   Description: Generates a list of bower dependencies for a project

--- a/test/helper.js
+++ b/test/helper.js
@@ -9,6 +9,15 @@ let getReport = (filename) => {
 	return fs.readFileSync(filename, 'utf8');
 };
 
+// Yarn and npm generate different package.json for installed packages.
+// This normalizes the generated report (string) so that it matches
+//   the expected output from an `npm install`.
+let normalizeReport = report => {
+	// npm creates a "homepage" property for "bower-license", but yarn does not.
+	let homepageLine = '  URL: https://github.com/AceMetrix/bower-license#readme\n';
+	return report.replace(/(bower-license\n)( {2}Version:)/, `$1${homepageLine}$2`);
+};
+
 // Custom Jasmine matchers to check if the value is a Report object.
 let toBeReport = (util, customEqualityTesters) => {
 	return {
@@ -35,3 +44,4 @@ exports.customMatchers = {
 	toBeReport: toBeReport
 };
 exports.getReport = getReport;
+exports.normalizeReport = normalizeReport;

--- a/test/option-include.spec.js
+++ b/test/option-include.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 describe('"include" option', () => {
 
-	const helper = require('./helper');
+	const { getReport, normalizeReport } = require('./helper');
 	const module = require('../');
 	const path = require('path');
 
@@ -10,7 +10,7 @@ describe('"include" option', () => {
 	describe('as ["dev"]', () => {
 
 		beforeAll(done => {
-			expectedReport = helper.getReport('dev-report.txt');
+			expectedReport = getReport('dev-report.txt');
 			module.generateReport({ include: ['dev'] })
 				.then(r => { report = r; })
 				.then(done)
@@ -18,7 +18,7 @@ describe('"include" option', () => {
 		});
 
 		it('should only include dev deps', () => {
-			expect(report.toString()).toBe(expectedReport);
+			expect(normalizeReport(report.toString())).toBe(expectedReport);
 		});
 
 		it('should not throw an error if "devDependencies" is not defined', done => {
@@ -40,7 +40,7 @@ describe('"include" option', () => {
 	describe('as ["npm"]', () => {
 
 		beforeAll(done => {
-			expectedReport = helper.getReport('default-report.txt');
+			expectedReport = getReport('default-report.txt');
 			module.generateReport({ include: ['npm'] })
 				.then(r => { report = r; })
 				.then(done)
@@ -48,7 +48,7 @@ describe('"include" option', () => {
 		});
 
 		it('should only include production deps', () => {
-			expect(report.toString()).toBe(expectedReport);
+			expect(normalizeReport(report.toString())).toBe(expectedReport);
 		});
 
 	});
@@ -56,7 +56,7 @@ describe('"include" option', () => {
 	describe('as ["dev", "npm"]', () => {
 
 		beforeAll(done => {
-			expectedReport = helper.getReport('all-deps-report.txt');
+			expectedReport = getReport('all-deps-report.txt');
 			module.generateReport({ include: ['dev', 'npm'] })
 				.then(r => { report = r; })
 				.then(done)
@@ -64,7 +64,7 @@ describe('"include" option', () => {
 		});
 
 		it('should include all deps', () => {
-			expect(report.toString()).toBe(expectedReport);
+			expect(normalizeReport(report.toString())).toBe(expectedReport);
 		});
 
 	});


### PR DESCRIPTION
Yarn and npm generate a different package.json for installed packages (e.g. "homepage" for the bower-license module).

This fixes the tests so that they match the expected output from an `npm install`.

Also specifies a Node v6+ requirement in the `package.json` (since we're using destructuring).